### PR TITLE
Add memory metrics interfaces

### DIFF
--- a/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics.interface.yaml
@@ -1,0 +1,11 @@
+description: >
+    Implement to provide memory metrics attributes.
+properties:
+    - name: BlockSizeBytes
+      type: uint64
+      description: >
+          Block size in bytes of all structure elements.
+    - name: BandwidthPercent
+      type: uint64
+      description: >
+          Bandwith utilization as percentage.

--- a/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics/CurrentPeriod.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics/CurrentPeriod.interface.yaml
@@ -1,0 +1,11 @@
+description: >
+    Implement to provide current period I/O memory counter attributes.
+properties:
+    - name: BlockRead
+      type: uint64
+      description: >
+          Number of blocks read in a single reset period.
+    - name: BlockWritten
+      type: uint64
+      description: >
+          Number of blocks written in a single reset period.

--- a/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics/HealthData.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics/HealthData.interface.yaml
@@ -1,0 +1,23 @@
+description: >
+    Implement to provide memory health data attributes.
+properties:
+    - name: RemainingSpareBlockPercentage
+      type: uint64
+      description: >
+          Remaining spare blocks in percentage.
+    - name: LastShutdownSuccess
+      type: boolean
+      description: >
+          Bandwith utilization as percentage.
+    - name: DataLossDetected
+      type: boolean
+      description: >
+          Bandwith utilization as percentage.
+    - name: PerformanceDegraded
+      type: boolean
+      description: >
+          Bandwith utilization as percentage.
+    - name: PredictedMediaLifeLeftPercentage
+      type: uint64
+      description: >
+          Percentage of life remaining in the media.

--- a/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics/HealthData/AlarmTrips.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics/HealthData/AlarmTrips.interface.yaml
@@ -1,0 +1,27 @@
+description: >
+    Implement to provide memory alarm trip attributes.
+properties:
+    - name: AdressParityError
+      type: boolean
+      description: >
+          Indicate if address parity error was detected.
+    - name: CorrectableECCError
+      type: boolean
+      description: >
+          Indicate if correctable error threshold
+          crossing alarm trip was detected.
+    - name: SpareBlock
+      type: boolean
+      description: >
+          Indicate if spare block capacity
+          crossing alarm trip was detected.
+    - name: Temperature
+      type: boolean
+      description: >
+          Indicate if a tempeprature threshold
+          alarm trip was detected.
+    - name: UncorrectableECCError
+      type: boolean
+      description: >
+          Indicate if uncorrectable error threshold
+          crossing alarm trip was detected.

--- a/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics/LifeTime.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Dimm/MemoryMetrics/LifeTime.interface.yaml
@@ -1,0 +1,11 @@
+description: >
+    Implement to provide lifetime I/O memory counter attributes.
+properties:
+    - name: BlockRead
+      type: uint64
+      description: >
+          Number of blocks read in a lifetime period.
+    - name: BlockWritten
+      type: uint64
+      description: >
+          Number of blocks written in a lifetime period.


### PR DESCRIPTION
Changes include:
- add MemoryMetrics interface
- add HealthData interface
- add AlarmTrips interface
- add LifeTime interface
- add CurrentPeriod interface

New properties for MemoryMetrics:
BlockSizeBytes, BandwidthPercent

New properties for HealthData:
RemainingSpareBlockPercentage, LastShutdownSuccess,
DataLossDetected, PerformanceDegraded,
PredictedMediaLifeLeftPercentage

New properties for AlarmTrips:
AddressParityError, CorrectableECCError, SpareBlock,
Temperature, UncorrectableECCError

New properties for LifeTime:
BlockRead, BlockWritten

New properties for CurrentPeriod:
BlockRead, BlockWritten

Change-Id: Ieb304c76663b8fc5b0c39cff8cbacc9de09ad933
Signed-off-by: Jan Drachal <jan.drachal@intel.com>