### PR TITLE
Spdm related schema added to phosphor-dbus-interfaces

### DIFF
--- a/gen/xyz/openbmc_project/Chassis/TrustedComponent/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/TrustedComponent/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Chassis/TrustedComponent__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Chassis/TrustedComponent.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Chassis/TrustedComponent',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Chassis/meson.build
+++ b/gen/xyz/openbmc_project/Chassis/meson.build
@@ -31,3 +31,18 @@ generated_others += custom_target(
     ],
 )
 
+subdir('TrustedComponent')
+generated_others += custom_target(
+    'xyz/openbmc_project/Chassis/TrustedComponent__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/Chassis/TrustedComponent.interface.yaml',  ],
+    output: [ 'TrustedComponent.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Chassis/TrustedComponent',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication/meson.build
+++ b/gen/xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet/meson.build
+++ b/gen/xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/ComponentIntegrity/SPDM/meson.build
+++ b/gen/xyz/openbmc_project/ComponentIntegrity/SPDM/meson.build
@@ -1,0 +1,45 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/ComponentIntegrity/SPDM__cpp'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/ComponentIntegrity/SPDM.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/ComponentIntegrity/SPDM',
+    ],
+)
+
+subdir('IdentityAuthentication')
+generated_others += custom_target(
+    'xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication.interface.yaml',  ],
+    output: [ 'IdentityAuthentication.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication',
+    ],
+)
+
+subdir('MeasurementSet')
+generated_others += custom_target(
+    'xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet.interface.yaml',  ],
+    output: [ 'MeasurementSet.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/ComponentIntegrity/meson.build
+++ b/gen/xyz/openbmc_project/ComponentIntegrity/meson.build
@@ -1,0 +1,30 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/ComponentIntegrity__cpp'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/ComponentIntegrity.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/ComponentIntegrity',
+    ],
+)
+
+subdir('SPDM')
+generated_others += custom_target(
+    'xyz/openbmc_project/ComponentIntegrity/SPDM__markdown'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/ComponentIntegrity/SPDM.interface.yaml',  ],
+    output: [ 'SPDM.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/ComponentIntegrity/SPDM',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Inventory/Item/Rot/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/Rot/meson.build
@@ -1,0 +1,15 @@
+# Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Inventory/Item/Rot__cpp'.underscorify(),
+    input: [ '../../../../../../yaml/xyz/openbmc_project/Inventory/Item/Rot.interface.yaml',  ],
+    output: [ 'common.hpp', 'server.cpp', 'server.hpp', 'client.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../../yaml',
+        'xyz/openbmc_project/Inventory/Item/Rot',
+    ],
+)
+

--- a/gen/xyz/openbmc_project/Inventory/Item/meson.build
+++ b/gen/xyz/openbmc_project/Inventory/Item/meson.build
@@ -358,6 +358,21 @@ generated_others += custom_target(
     ],
 )
 
+subdir('Rot')
+generated_others += custom_target(
+    'xyz/openbmc_project/Inventory/Item/Rot__markdown'.underscorify(),
+    input: [ '../../../../../yaml/xyz/openbmc_project/Inventory/Item/Rot.interface.yaml',  ],
+    output: [ 'Rot.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../../yaml',
+        'xyz/openbmc_project/Inventory/Item/Rot',
+    ],
+)
+
 subdir('Rotor')
 generated_others += custom_target(
     'xyz/openbmc_project/Inventory/Item/Rotor__markdown'.underscorify(),

--- a/gen/xyz/openbmc_project/meson.build
+++ b/gen/xyz/openbmc_project/meson.build
@@ -48,6 +48,21 @@ generated_others += custom_target(
     ],
 )
 
+subdir('ComponentIntegrity')
+generated_others += custom_target(
+    'xyz/openbmc_project/ComponentIntegrity__markdown'.underscorify(),
+    input: [ '../../../yaml/xyz/openbmc_project/ComponentIntegrity.interface.yaml',  ],
+    output: [ 'ComponentIntegrity.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../yaml',
+        'xyz/openbmc_project/ComponentIntegrity',
+    ],
+)
+
 subdir('Condition')
 subdir('Console')
 subdir('Control')

--- a/yaml/xyz/openbmc_project/Chassis/TrustedComponent.interface.yaml
+++ b/yaml/xyz/openbmc_project/Chassis/TrustedComponent.interface.yaml
@@ -1,0 +1,83 @@
+description: >
+    Interface to query trusted component info.
+
+properties:
+    - name: Certificates
+      type: object_path
+      description: >
+          Path to a collection of device identity certificates
+          of the trusted component.
+
+    - name: FirmwareVersion
+      type: string
+      description: >
+          The software version of the active software image on the trusted
+          component.
+
+    - name: ActiveSoftwareImage 
+      type: object_path
+      description: >
+          The object path of the software inventory resource that represents
+          the active firmware image for this trusted component.
+
+    - name: ComponentIntegrity
+      type: array[object_path]
+      description: >
+          An array of objects of ComponentIntegrity resources for which the
+          trusted component is responsible.
+
+    - name: ComponentsProtected
+      type: array[object_path]
+      description: >
+          An array of object paths to resources that the target component
+          protects.
+
+    - name: IntegratedInto 
+      type: object_path 
+      description: >
+          An object path to a resource to which this trusted component is
+          integrated.
+
+    - name: SoftwareImages 
+      type: array[object_path] 
+      description: >
+          The images that are associated with this trusted component.
+
+    - name: Manufacturer
+      type: string
+      description: >
+          The manufacturer of this trusted component.
+
+    - name: SerialNumber
+      type: string
+      description: >
+          The serial number of the trusted component.
+
+    - name: SKU
+      type: string
+      description: >
+          The SKU of the trusted component.
+
+    - name: TrustedComponentType
+      type: enum[self.ComponentAttachType]
+      description: >
+          The type of trusted component, such as any physical distinction
+          about the trusted component.
+
+    - name: UUID
+      type: string
+      description: >
+          The UUID for this trusted component.
+
+enumerations:
+    - name: ComponentAttachType
+      description: >
+          The type of trusted component, such as any physical distinction
+          about the trusted component.
+      values:
+          - name: Discrete
+            description: >
+                A discrete trusted component.
+          - name: Integrated
+            description: >
+                An integrated trusted component.

--- a/yaml/xyz/openbmc_project/ComponentIntegrity.interface.yaml
+++ b/yaml/xyz/openbmc_project/ComponentIntegrity.interface.yaml
@@ -1,0 +1,71 @@
+description: >
+    Implement to represent component integrity information acquired from
+    a secure authentication or measurement of the protected components.
+
+    A trusted component (e.g., iRoT or TPM) is typically involved to
+    provide the info using a security protocol (e.g., SPDM).
+properties:
+    - name: Enabled
+      type: boolean
+      description: >
+          An indication of whether security protocols are
+          enabled for the component.
+
+    - name: Type
+      type: enum[self.SecurityTechnologyType]
+      description: >
+          The type of security technology for the
+          component.
+
+    - name: TypeVersion
+      type: string
+      description: >
+          The version of the security technology.
+
+    - name: LastUpdated
+      type: string
+      description: >
+          The date and time when information for the
+          component was last updated.
+
+          The date of component update in ISO 8601 format as
+          YYYYMMDDThhmmssZ.  Where 'T' is a literal character
+          to separate date fields from time and 'Z' is a literal character
+          to indicate UTC.
+
+    - name: TargetComponentURI
+      type: object_path
+      description: >
+          The link to the the component whose integrity
+          that this resource reports.
+      errors:
+          # Indicate that the set object_path is not valid.
+          - xyz.openbmc_project.Common.Error.InvalidArgument
+          # Indicate that this property is permanently unable to be changed.
+          - xyz.openbmc_project.Common.Error.NotAllowed
+          # Indicate that this property is temporarily unable to be changed.
+          - xyz.openbmc_project.Common.Error.Unavailable
+          # Indicate that this property is temporarily unable to be changed.
+          - xyz.openbmc_project.Common.Error.InternalFailure
+
+    - name: ComponentsProtected
+      type: array[object_path]
+      description: >
+          An array of objects that the target
+          component protects.
+
+
+enumerations:
+    - name: SecurityTechnologyType
+      description: >
+          The security technology used for the component.
+      values:
+          - name: OEM
+            description: >
+                OEM-specific.
+          - name: SPDM
+            description: >
+                Security Protocol and Data Model (SPDM) protocol.
+          - name: TPM
+            description: >
+                Trusted Platform Module (TPM).

--- a/yaml/xyz/openbmc_project/ComponentIntegrity/SPDM.interface.yaml
+++ b/yaml/xyz/openbmc_project/ComponentIntegrity/SPDM.interface.yaml
@@ -1,0 +1,9 @@
+description: >
+    Implement to represent SPDM related properties.
+
+properties:
+    - name: Requester
+      type: object_path
+      description: >
+          The component that is reporting the integrity
+          information of the target component.

--- a/yaml/xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication.interface.yaml
+++ b/yaml/xyz/openbmc_project/ComponentIntegrity/SPDM/IdentityAuthentication.interface.yaml
@@ -1,0 +1,36 @@
+description: >
+    Implement to represent properties related to
+    Identity Authentication using SPDM protocol.
+
+properties:
+    - name: RequesterAuthentication
+      type: object_path
+      description: >
+          Authentication information of the identity of the
+          SPDM Requester. Typically the path of the certificate
+          object of the SPDM Requester.
+
+    - name: ResponderAuthentication
+      type: object_path
+      description: >
+          Authentication information of the identity of the
+          SPDM Responder. Typically the path of the certificate
+          object of the SPDM Responder.
+
+    - name: ResponderVerificationStatus
+      type: enum[self.VerificationStatus]
+      description: >
+          The status of the verification of the identity of the
+          component. 
+
+enumerations:
+    - name: VerificationStatus
+      description: >
+          The possible status of the verification.
+      values:
+          - name: Failed
+            description: >
+                Unsuccessful verification.
+          - name: Success
+            description: >
+                Successful verification.

--- a/yaml/xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet.interface.yaml
+++ b/yaml/xyz/openbmc_project/ComponentIntegrity/SPDM/MeasurementSet.interface.yaml
@@ -1,0 +1,43 @@
+description: >
+    Implement to represent properties related to
+    SPDM Measurements set.
+
+methods:
+    - name: SPDMGetSignedMeasurements
+      description: >
+          This method generates an SPDM cryptographic signed statement over
+          the given nonce and measurements of the SPDM Responder.
+
+      parameters:
+          - name: MeasurementIndices
+            type: array[uint32]
+            description: >
+                An array of indices that identify the measurement blocks to
+                sign.
+
+          - name: Nonce
+            type: string
+            description: >
+                A 32-byte hex-encoded string that is signed with the
+                measurements. The value should be unique.
+
+          - name: SlotId
+            type: uint32
+            description: >
+                The slot identifier for the certificate containing the private
+                key to generate the signature over the measurements.
+
+      returns:
+          - name: MeasurementResponse
+            type: struct[object_path, string, string, string, string, string]
+            description: >
+                The response will contain a struct with following fields:
+                Certificate, HashingAlgorithm, PublicKey, SignedMeasurements,
+                SignedAlgorithm, Version.
+
+                Among them, Certificate refers to certificate object
+                corresponding to the SPDM slot identifier that can be used
+                to validate the signature. 
+
+      errors:
+          - xyz.openbmc_project.Common.Error.InvalidArgument

--- a/yaml/xyz/openbmc_project/Inventory/Item/Rot.interface.yaml
+++ b/yaml/xyz/openbmc_project/Inventory/Item/Rot.interface.yaml
@@ -1,0 +1,2 @@
+description: >
+    Implement to provide Root of Trust(RoT) attributes, e.g., SPDM attestation.


### PR DESCRIPTION
The D-Bus Interface for ComponentIntegrity and TrustedComponent is
based on DSP2046_2022.3.pdf. These two interfaces are needed to
implement the SPDM D-Bus agent.

Add Inventory/Item/Rot.interface to represent root of trust.
This is optional. It makes enumerating SPDM-capable devices
or other Root-of-trust devices easier.

Note, yaml files define the interfaces. meson files are automatically generated
from the yaml files and are used for building the dbus phosphor interface
library.